### PR TITLE
adds get_post function to return the underlying WP_Post

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "A plugin for WordPress that makes post types easier to manage",
   "minimum-stability": "stable",
   "license": "GPL-3.0",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "autoload": {
     "psr-4": {
       "Outlandish\\Wordpress\\Oowp\\": "src/"

--- a/src/PostTypes/WordpressPost.php
+++ b/src/PostTypes/WordpressPost.php
@@ -97,6 +97,13 @@ abstract class WordpressPost
 	}
 
 	/**
+	 * Return the underlying WP_Post
+	 */
+	public function get_post() {
+	    return $this->post;
+        }
+
+	/**
 	 * Override this to hook into the save event. This is called with low priority so
 	 * all fields should be already saved
 	 */


### PR DESCRIPTION
This is to support making the `global $post` a `WP_Post` in Routemaster's `OowpRouterHelper->querySingle()` function.