### PR TITLE
added fix for fields being passed as query args - 

### DIFF
--- a/src/OowpQuery.php
+++ b/src/OowpQuery.php
@@ -107,6 +107,11 @@ class OowpQuery extends \WP_Query implements \IteratorAggregate, \ArrayAccess, \
 	public function &get_posts() {
 		parent::get_posts();
 
+        if(isset($this->query['fields']) && ($this->query['fields'] != "all")){
+            //just the ids have been requested (or 'id=>parent' objects), rather than post objects
+            return $this->posts;
+        }
+
 		foreach ($this->posts as $i => $post) {
 			$this->posts[$i] = WordpressPost::createWordpressPost($post);
 		}


### PR DESCRIPTION
previously the fields parameter was ignored and full posts were returned.

It's useful to support this behaviour as otherwise you sometimes need to resort to using a standard WP_Query which doesn't benefit from the posts type's default args (e.g. 'sortby' => 'title')