### PR TITLE
Align `fetchOne()` post type constraints with similar methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+composer.lock

--- a/src/PostTypeManager.php
+++ b/src/PostTypeManager.php
@@ -119,6 +119,21 @@ class PostTypeManager
 		return array_key_exists($postType, $classNames) ? $classNames[$postType] : null;
     }
 
+    /**
+     * Returns true if the given fully-qualified class name represents a post type
+     * registered via registerPostTypes().
+     * @param string $className Fully-qualified name of a class which might be a post type.
+     * @return bool
+     */
+    public function postClassIsRegistered($className)
+    {
+        if (!class_exists($className)) {
+            return false;
+        }
+
+        return array_key_exists($className, $this->postTypes);
+    }
+
 	/**
 	 * Returns true if the post type was registered via registerPostTypes()
 	 * @param string $postType

--- a/src/PostTypes/WordpressPost.php
+++ b/src/PostTypes/WordpressPost.php
@@ -1081,9 +1081,9 @@ abstract class WordpressPost
 
     private static function getSelfPostTypeConstraint()
     {
-        // If `get*()` methods are called on `WordpressPost` directly (not a subclass), do not
+        // If `get*()` methods are called on abstract post classes directly (not a subclass), do not
         // constrain the type of posts returned unless specified.
-        if (static::class === self::class) {
+        if (in_array(static::class, array(self::class, RoutemasterPost::class), true)) {
             return 'any';
         }
 

--- a/src/PostTypes/WordpressPost.php
+++ b/src/PostTypes/WordpressPost.php
@@ -1081,9 +1081,9 @@ abstract class WordpressPost
 
     private static function getSelfPostTypeConstraint()
     {
-        // If `get*()` methods are called on abstract post classes directly (not a subclass), do not
+        // If `get*()` methods are called on abstract post classes directly (not a registered post subclass), do not
         // constrain the type of posts returned unless specified.
-        if (in_array(static::class, array(self::class, RoutemasterPost::class), true)) {
+        if (!PostTypeManager::get()->postClassIsRegistered(static::class)) {
             return 'any';
         }
 

--- a/src/PostTypes/WordpressPost.php
+++ b/src/PostTypes/WordpressPost.php
@@ -983,11 +983,7 @@ abstract class WordpressPost
 	}
 
 	public static function fetchBySlug($slug){
-		return static::fetchOne(array(
-			'name' => $slug,
-			'post_type' => static::getSelfPostTypeConstraint(),
-			'numberposts' => 1
-		));
+		return static::fetchOne(array('name' => $slug));
 	}
 
 	/**


### PR DESCRIPTION
Also make them all more resilient in the case of direct invocation on `WordpressPost`. Fixes #13