### PR TITLE
Fix title retrieval

### DIFF
--- a/src/WordpressTheme.php
+++ b/src/WordpressTheme.php
@@ -112,7 +112,7 @@ class WordpressTheme
 
     public function htmlTitle()
     {
-        return wp_title('&laquo;', true, 'right') . ' ' . $this->siteTitle();
+        return wp_title('&laquo;', false, 'right') . ' ' . $this->siteTitle();
     }
 
     /**


### PR DESCRIPTION
As `wp_title()` ends with

```php
    // Send it out.
    if ( $display ) {
        echo $title;
    } else {
        return $title;
    }
```

https://developer.wordpress.org/reference/functions/wp_title/

Discovered by @phpstan, see #16 