### PR TITLE
Return a single post type, not an array

### DIFF
--- a/src/OowpQuery.php
+++ b/src/OowpQuery.php
@@ -28,7 +28,7 @@ class OowpQuery extends \WP_Query implements \IteratorAggregate, \ArrayAccess, \
         $validPostTypes    = get_post_types();
         $requestedPostType = $query['post_type'] ?? 'any';
         if (is_scalar($requestedPostType) && !array_key_exists($requestedPostType, $validPostTypes)) {
-            $query['post_type'] = array_values(array_diff($validPostTypes, ['attachment']));
+            $query['post_type'] = array_values(array_diff($validPostTypes, ['attachment']))[0];
         }
 
         parent::__construct($query);


### PR DESCRIPTION
Fixes error happening on prospect when trying to render menu item. 
The current code returns a whole array, while it should be returning a string. 
It was introduced at https://github.com/outlandishideas/oowp/pull/20
Before it was returning the word 'any'