### PR TITLE
Make return types of functions compatible with parents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     }
   ],
   "require": {
+    "php": ">=7.0",
     "composer/installers": "^1.0 || ^2.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1",
     "composer/installers": "^1.0 || ^2.0"
   }
 }

--- a/src/OowpQuery.php
+++ b/src/OowpQuery.php
@@ -40,7 +40,7 @@ class OowpQuery extends \WP_Query implements \IteratorAggregate, \ArrayAccess, \
 
     /* Interfaces */
 
-    public function getIterator(): Traversable
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->posts);
     }

--- a/src/OowpQuery.php
+++ b/src/OowpQuery.php
@@ -40,7 +40,7 @@ class OowpQuery extends \WP_Query implements \IteratorAggregate, \ArrayAccess, \
 
     /* Interfaces */
 
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new \ArrayIterator($this->posts);
     }
@@ -50,7 +50,7 @@ class OowpQuery extends \WP_Query implements \IteratorAggregate, \ArrayAccess, \
         return isset($this->posts[$offset]);
     }
 
-    public function offsetGet($offset): bool
+    public function offsetGet($offset): mixed
     {
         return $this->posts[$offset];
     }

--- a/src/OowpQuery.php
+++ b/src/OowpQuery.php
@@ -45,27 +45,27 @@ class OowpQuery extends \WP_Query implements \IteratorAggregate, \ArrayAccess, \
         return new \ArrayIterator($this->posts);
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->posts[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): bool
     {
         return $this->posts[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->posts[$offset] = $value;
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->posts[$offset]);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->posts);
     }


### PR DESCRIPTION
related to the PHP 8.0+ changes in method signature compatibility when implementing interfaces or extending classes. Children classes that overwrite parent classes must have the same return type